### PR TITLE
Deploy to Azure as a Static Web App

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-pond-0e5b7781e.yml
+++ b/.github/workflows/azure-static-web-apps-mango-pond-0e5b7781e.yml
@@ -3,11 +3,11 @@ name: Azure Static Web Apps CI/CD
 on:
   push:
     branches:
-      - main
+      - fix-static-deployment-pipeline
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
-      - main
+      - fix-static-deployment-pipeline
 
 jobs:
   build_and_deploy_job:

--- a/.github/workflows/azure-static-web-apps-mango-pond-0e5b7781e.yml
+++ b/.github/workflows/azure-static-web-apps-mango-pond-0e5b7781e.yml
@@ -1,13 +1,16 @@
+# Azure Static Web Apps CI/CD workflow for Mango Pond: https://mango-pond-0e5b7781e.3.azurestaticapps.net
+# Azure Portal -> Static Web Apps -> game-store-angular4
+
 name: Azure Static Web Apps CI/CD
 
 on:
   push:
     branches:
-      - fix-static-deployment-pipeline
+      - main
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
-      - fix-static-deployment-pipeline
+      - main
 
 jobs:
   build_and_deploy_job:

--- a/.github/workflows/azure-static-web-apps-mango-pond-0e5b7781e.yml
+++ b/.github/workflows/azure-static-web-apps-mango-pond-0e5b7781e.yml
@@ -1,8 +1,8 @@
 # Azure Static Web Apps CI/CD workflow for Mango Pond: https://mango-pond-0e5b7781e.3.azurestaticapps.net
 # Azure Portal -> Static Web Apps -> game-store-angular4
-# This file was initially created by Azure when creating a new statci web app in the portal.
+# This file was initially created by Azure when creating a new static web app in the portal.
 
-name: Azure Static Web Apps CI/CD
+name: Azure Static Web Apps CI/CD for Game Store Angular
 
 on:
   push:

--- a/.github/workflows/azure-static-web-apps-mango-pond-0e5b7781e.yml
+++ b/.github/workflows/azure-static-web-apps-mango-pond-0e5b7781e.yml
@@ -1,5 +1,6 @@
 # Azure Static Web Apps CI/CD workflow for Mango Pond: https://mango-pond-0e5b7781e.3.azurestaticapps.net
 # Azure Portal -> Static Web Apps -> game-store-angular4
+# This file was initially created by Azure when creating a new statci web app in the portal.
 
 name: Azure Static Web Apps CI/CD
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ chrome-profiler-events*.json
 
 # IDEs and editors
 /.idea
+.vscode
 .project
 .classpath
 .c9/

--- a/package.json
+++ b/package.json
@@ -57,5 +57,9 @@
     "prettier": "^3.6.2",
     "typescript": "5.8.3",
     "typescript-eslint": "8.46.0"
+  },
+  "engines": {
+    "node": "20.19.5",
+    "npm": "10.8.2"
   }
 }


### PR DESCRIPTION
The workflow file `azure-static-web-apps-mango-pond-0e5b7781e.yml` was initially created by Azure when creating a new static web app in the portal.
<img width="1585" height="1091" alt="image" src="https://github.com/user-attachments/assets/4d9793e2-2acd-4ffa-a00b-e8583d6ae684" />


In this PR, I'm trying to add node version to `package.json` to fix this deployment to Azure. If build is successful, static files will be deployed to https://mango-pond-0e5b7781e.3.azurestaticapps.net .
<img width="1271" height="564" alt="image" src="https://github.com/user-attachments/assets/82cec413-1d88-4c5c-b995-d24330f4957b" />

