### PR TITLE
Refine pipeline for the deployment of static web app

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-pond-0e5b7781e.yml
+++ b/.github/workflows/azure-static-web-apps-mango-pond-0e5b7781e.yml
@@ -7,56 +7,47 @@ name: Azure Static Web Apps CI/CD for Game Store Angular
 on:
   push:
     branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - main
+      - update-api-url-for-azure-static-web
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     permissions:
-       id-token: write
-       contents: read
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
           lfs: false
+
+      # Set Node version explicitly
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Install OIDC Client from Core Package
         run: npm install @actions/core@1.6.0 @actions/http-client
+
       - name: Get Id Token
         uses: actions/github-script@v6
         id: idtoken
         with:
-           script: |
-               const coredemo = require('@actions/core')
-               return await coredemo.getIDToken()
-           result-encoding: string
+          script: |
+            const coredemo = require('@actions/core')
+            return await coredemo.getIDToken()
+          result-encoding: string
+
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_MANGO_POND_0E5B7781E }}
           action: "upload"
-          ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
-          # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "/" # App source code path
-          api_location: "" # Api source code path - optional
-          output_location: "dist/browser" # Built app content directory - optional
+          app_location: "/"              # Path to app source
+          api_location: ""               # Path to API if any
+          app_build_command: "npm ci && npx ng build --configuration=azure"
+          output_location: "dist/browser" # Angular build output
           github_id_token: ${{ steps.idtoken.outputs.result }}
-          ###### End of Repository/Build Configurations ######
 
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          action: "close"

--- a/.github/workflows/azure-static-web-apps-mango-pond-0e5b7781e.yml
+++ b/.github/workflows/azure-static-web-apps-mango-pond-0e5b7781e.yml
@@ -7,7 +7,7 @@ name: Azure Static Web Apps CI/CD for Game Store Angular
 on:
   push:
     branches:
-      - update-api-url-for-azure-static-web
+      - main
 
 jobs:
   build_and_deploy_job:


### PR DESCRIPTION
1. The pipeline for static web app should only be triggered on `main` branch.

2. Customize the build command with `app_build_command` to point the backend api to azure.

Access the static web site https://mango-pond-0e5b7781e.3.azurestaticapps.net/products .
<img width="1339" height="1052" alt="image" src="https://github.com/user-attachments/assets/e4ef7ffd-dbb7-4671-ab7b-2ecc569ef690" />
